### PR TITLE
WIP: altjtheta1

### DIFF
--- a/src/EllipticFunctions.jl
+++ b/src/EllipticFunctions.jl
@@ -1000,9 +1000,16 @@ function _calctheta1_alt1(z::Number, q::Number)
   n = -1
   series = zero(promote_type(typeof(z), typeof(q)))
   maxiter = 3000
+  q² = q * q
+  q²ⁿ = one(q)
+  qⁿ⁽ⁿ⁺¹⁾ = one(q)
   while n < maxiter
     n += 1
-    term = q^(n*(n+1)) * sin((2n+1)*z)
+    if n > 0
+      q²ⁿ *= q²
+      qⁿ⁽ⁿ⁺¹⁾ *= q²ⁿ
+    end
+    term = qⁿ⁽ⁿ⁺¹⁾ * sin((2n+1)*z)
     isodd(n) && (term = -term)
     nextseries = series + term
     if n ≥ 2 && areclose(nextseries, series)
@@ -1019,7 +1026,7 @@ end
     _calctheta1_alt2(zopi::Number, topi::Number)
 
 Calculate the Jacobian elliptic theta function θ₁ using the Poisson summation
-formula.  Most useful for 0 < Im(tau) ≤ 1/π.  
+formula.  Most useful for 0 < Im(tau) ≤ 1.3.  
 
 # Input Arguments:
 - `zopi`: z/π, where z is the first argument of the theta function.


### PR DESCRIPTION
As the name indicates, this is a work in progress.  I'm soliciting your comments and direction as to whether I should push ahead with these modifications.

# TLDR
I've implemented an alternative evaluation scheme for `jtheta1(z,tau)` which is often much faster (as much as 10x faster for real `z` and pure imaginary `tau`) than the presently implemented algorithm.  Because my proposed changes are so disruptive, I'd like your take on this and whether I should continue to work on the remaining three functions.  Also, I would like to suggest using the nome `q = exp(im * pi * tau)` rather than `tau` as the second argument to the functions `jtheta1`, ..., `jtheta4` .  I make arguments for this below.

# The Details
When I saw your Discourse posts and package it stirred up some memories from more than 30 years ago.  I remember seeing some alternative series for the Jacobi theta functions, but couldn't find the source (it was probably a book from the library at my then workplace, which is long since gone).  But I played around and reconstructed the series for the $\theta_1$ function using the Poisson summation formula (notes attached below).  The alternative series has the nice property that it converges fastest where the imaginary part of `tau` is small, so it nicely complements the original [NIST series](https://dlmf.nist.gov/20.2.i), which converges fastest where this quantity is large.  So I coded up a function named `altjtheta1` which uses these two series and made some timing and accuracy comparisons to `jtheta1`.  The reference values for accuracy are from Wolfram Alpha:
```julia
julia> using EllipticFunctions # I have the altthetas branch checked out

julia> using BenchmarkTools 
```
The first example has the most advantage for this PR: `z` is pure real and `tau` is pure imaginary and small:
```julia
julia> @btime EllipticFunctions.jtheta1(20, 0.01*im)
  307.236 ns (0 allocations: 0 bytes)
0.03608696080199044 - 2.6516268622268154e-17im

julia> @btime EllipticFunctions.altjtheta1(20, 0.01*im)
  31.570 ns (0 allocations: 0 bytes)
0.03608696080206553 + 0.0im

julia> # Wolfram Alpha: 0.0360869608020636316
```
`altjtheta1` provides several more accurate digits, returns a zero imaginary part, and is almost ten times faster than `jtheta1`.  There are several reasons for the speed difference:

1. The fact that both `z` and `q = xcispi(tau)` are pure real is exploited so that all the calculations are done on `Float64` reals.  This also accounts for the pure real result.
2. The Poisson transformed series used in this case converges faster as `imag(tau)` decreases, and this is a quite small value.

I attribute the greater accuracy to the fact that small errors are introduced in `jtheta1` from the multiple modular transformations required.

The choice as to whether the original or transformed series is used is according to whether `imag(tau)` is greater than (original) or less than or equal to (transformed) 1.3.  Here is an example where we are slightly above this decision point:
```julia
julia> @btime EllipticFunctions.jtheta1(-2, 1.4*im)
  230.073 ns (0 allocations: 0 bytes)
-0.6056537639933428 + 1.9479310714792054e-16im

julia> @btime EllipticFunctions.altjtheta1(-2, 1.4*im)
  200.333 ns (0 allocations: 0 bytes)
-0.6056537639933426 + 0.0im

julia> # Wolfram Alpha: -0.605653763993342615
```
Here the speed is comparable and `altjtheta1` is only very slightly more accurate.

As the imaginary part of `tau` increases, `alttheta1` starts to regain an advantage:
```julia
julia> @btime EllipticFunctions.jtheta1(-2, 2.2*im)
  195.487 ns (0 allocations: 0 bytes)
-0.323094150693883 + 1.0391500434177393e-16im

julia> @btime EllipticFunctions.altjtheta1(-2, 2.2*im)
  110.673 ns (0 allocations: 0 bytes)
-0.32309415069388303 + 0.0im

julia> # Wolfram Alpha: -0.323094150693883056
```
 Here `altjtheta1` is significantly faster and perhaps more accurate by one digit.

Here is an example where both arguments are have nonzero real and imaginary parts:
```
julia> @btime EllipticFunctions.jtheta1(1.3 + 0.7im, 0.3 + 2.2*im)
  187.297 ns (0 allocations: 0 bytes)
0.40103039942452695 + 0.17043051360017036im

julia> @btime EllipticFunctions.altjtheta1(1.3 + 0.7im, 0.3 + 2.2*im)
  123.098 ns (0 allocations: 0 bytes)
0.40103039942452723 + 0.17043051360017042im

julia> # Wolfram Alpha: 0.401030399424527305 + 0.170430513600170463 i
```

Although this is by no means an exhaustive test, it looks like `altjtheta1` is at least as accurate and is usually faster, sometimes much faster, than `jtheta`.

# Additional Discussion
I realize that you have a very elegant code structure in place and this PR, if fully implemented, would mean a drastic change of direction.  I would like to make one more suggestion that would be a breaking change (but since you're not yet at version 1.0 I think this is acceptable):  I would like you to consider using the nome `q = cispi(tau)` as the second argument to the theta functions.  This would allow Julia's type system to eliminate the need for the shenanigans I implemented to exploit real-valued `z` and/or `q` values.  If one had `jtheta(z, q)`, then when a user invoked the function with `Float64` or other pure real-typed values, the compiler would specialize for these types, and the calculations would automatically be done in that type, returning a `Float64` value rather than a `ComplexF64` value.  This is how virtually all other Julia math functions behave.  It would simplify the user experience and result in faster code in the most commonly occurring case.

Thanks in advance for looking at this PR. 

[ThetaFunctions.pdf](https://github.com/stla/EllipticFunctions.jl/files/9074887/ThetaFunctions.pdf)

