### PR TITLE
Return Inf when appropriate

### DIFF
--- a/src/EllipticFunctions.jl
+++ b/src/EllipticFunctions.jl
@@ -40,6 +40,7 @@ function isqrt(x::Number)
 end
 
 function areclose(z1::Number, z2::Number)
+  isinf(z1) && isinf(z2) && (return true)
   eps2 = eps()^2
   mod2_z2 = abs2(z2)
   maxmod2 = (mod2_z2 < eps2) ? 1.0 : max(abs2(z1), mod2_z2)

--- a/src/EllipticFunctions.jl
+++ b/src/EllipticFunctions.jl
@@ -40,7 +40,7 @@ function isqrt(x::Number)
 end
 
 function areclose(z1::Number, z2::Number)
-  isinf(z1) && isinf(z2) && (return true)
+  z1 == z2 && (return true)
   eps2 = eps()^2
   mod2_z2 = abs2(z2)
   maxmod2 = (mod2_z2 < eps2) ? 1.0 : max(abs2(z1), mod2_z2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,8 @@ using Test
     jtheta4(1 + 1im, 1im),
     1.1351891564632007 + 0.28517396444192509im
   )
+  @test real(jtheta1(1-1im, 1.e-13*im)) == -Inf
+  @test imag(jtheta1(1-1im, 1.e-13*im)) == Inf
 end
 
 @testset "A value of jtheta1dash." begin


### PR DESCRIPTION
I was looking some more at the problematic case you discovered:
```julia
shell> git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean

julia> jtheta1(1+ 0.58im, 1.e-13*im)
ERROR: Reached 3000 terms.
...
```
I tried this on Wolfram Alpha with the following result (to 18 decimal places):
```
-2.31147846607338362×10^932003934434 + 1.18954904881950949×10^932003934434 i
```
Obviously, for Julia the correct answer should be `-Inf + Inf*im`.   This is actually what the code computes, but it isn't being returned because `areclose` doesn't find infinite results to be close to each other.  A slight modification to `areclose` fixes this, at the cost of an additional half-nanosecond of execution time, which seems a good tradeoff.  Also added a test for this case.  The result after this PR is:
```julia
julia> @btime jtheta1(1 - im, 1.e-13*im)
  146.312 ns (0 allocations: 0 bytes)
-Inf + Inf*im
```