### PR TITLE
Support extended precision types

### DIFF
--- a/src/EllipticFunctions.jl
+++ b/src/EllipticFunctions.jl
@@ -46,14 +46,14 @@ function isqrt(x::Number)
   return sqrt(Complex(x))
 end
 
-function areclose(z1::Number, z2::Number)
+function areclose(z1::S, z2::S) where {T <: Real, S <: Union{T, Complex{T}}}
   z1 == z2 && (return true)
-  eps2 = eps()^2
+  eps2 = eps(T)^2
   mod2_z2 = abs2(z2)
   maxmod2 = (mod2_z2 < eps2) ? 1.0 : max(abs2(z1), mod2_z2)
   return abs2(z1 - z2) < 4.0 * eps2 * maxmod2
 end
-
+  
 function _calctheta1_alt1(z::Number, q::Number)
   n = -1
   series = zero(promote_type(typeof(z), typeof(q)))


### PR DESCRIPTION
Another small change to `areclose` allows the code to work for extended precision types, such as `BigFloat`:
```julia
julia> wolfram = BigFloat("0.33978130612652614684672935483362300238452187145501621232488558105518977179930735")
0.3397813061265261468467293548336230023845218714550162123248855810551897717993083

julia> julia = jtheta1(BigFloat("0.3"), BigFloat("0.4")im)
0.3397813061265261468467293548336230023845218714550162123248855810551897717993083 + 0.0im

julia> wolfram - julia
0.0 - 0.0im
```
To allow rapid retrieval of the appropriate type, I constrained the two arguments of `areclose` to be the same type.  I don't think this is an issue (all existing tests pass), but wanted to point this out.

Probably needs a bunch of tests to ensure all the code is generic.  If you like the direction of this PR, I can work on the tests next, before merging, if you prefer.