### PR TITLE
Extended precision for CarlsonRF

### DIFF
--- a/src/EllipticFunctions.jl
+++ b/src/EllipticFunctions.jl
@@ -516,16 +516,14 @@ Carlson 'RF' integral.
 # Arguments
 - `x`,`y`,`z`: complex numbers; at most one of them can be zero
 """
-function CarlsonRF(x::Number, y::Number, z::Number)
+function CarlsonRF(xin::Number, yin::Number, zin::Number)
   local A
-  xzero = x == 0
-  yzero = y == 0
-  zzero = z == 0
+  (xzero, yzero, zzero) = iszero.((xin, yin, zin))
+  (x, y, z, _) = promote(xin, yin, zin, 1.0)
+  T = real(typeof(x))
   @assert xzero + yzero + zzero <= 1 ArgumentError("At most one of `x`, `y`, `z` can be 0.")
-  dx = typemax(Float64)
-  dy = typemax(Float64)
-  dz = typemax(Float64)
-  epsilon = 10.0 * eps()^2
+  dx = dy = dz = typemax(T)
+  epsilon = 10.0 * eps(T)^2
   while dx > epsilon || dy > epsilon || dz > epsilon
     lambda = isqrt(x)*isqrt(y) + isqrt(y)*isqrt(z) + isqrt(z)*isqrt(x)
     x = (x + lambda) / 4.0

--- a/src/EllipticFunctions.jl
+++ b/src/EllipticFunctions.jl
@@ -516,23 +516,23 @@ Carlson 'RF' integral.
 # Arguments
 - `x`,`y`,`z`: complex numbers; at most one of them can be zero
 """
-function CarlsonRF(xin::Number, yin::Number, zin::Number)
+function CarlsonRF(x::Number, y::Number, z::Number)
   local A
-  (xzero, yzero, zzero) = iszero.((xin, yin, zin))
-  (x, y, z, _) = promote(xin, yin, zin, 1.0)
-  T = real(typeof(x))
+  (xzero, yzero, zzero) = iszero.((x, y, z))
+  (xx, yy, zz, _) = promote(x, y, z, 1.0)
+  T = real(typeof(xx))
   @assert xzero + yzero + zzero <= 1 ArgumentError("At most one of `x`, `y`, `z` can be 0.")
   dx = dy = dz = typemax(T)
   epsilon = 10.0 * eps(T)^2
   while dx > epsilon || dy > epsilon || dz > epsilon
-    lambda = isqrt(x)*isqrt(y) + isqrt(y)*isqrt(z) + isqrt(z)*isqrt(x)
-    x = (x + lambda) / 4.0
-    y = (y + lambda) / 4.0
-    z = (z + lambda) / 4.0
-    A = (x + y + z) / 3.0
-    dx = abs2(1.0 - x/A)
-    dy = abs2(1.0 - y/A)
-    dz = abs2(1.0 - z/A)
+    lambda = isqrt(xx)*isqrt(yy) + isqrt(yy)*isqrt(zz) + isqrt(zz)*isqrt(xx)
+    xx = (xx + lambda) / 4.0
+    yy = (yy + lambda) / 4.0
+    zz = (zz + lambda) / 4.0
+    A = (xx + yy + zz) / 3.0
+    dx = abs2(1.0 - xx/A)
+    dy = abs2(1.0 - yy/A)
+    dz = abs2(1.0 - zz/A)
   end
   E2 = sqrt(dx*dy) + sqrt(dy*dz) + sqrt(dz*dx)
   E3 = sqrt(dy*dx*dz)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -199,6 +199,16 @@ end
   )
 end
 
+@testset "Extended Precision ellipticF" begin
+    setprecision(512) do
+        phi = parse(BigFloat, "0.15")
+        m = parse(BigFloat, "0.81")
+        I = ellipticF(phi, m)
+        IWolfram = parse(BigFloat, "0.15045731627390324557125914235016372659553548570625738854307684752660195708464381473254355631857978043355122247940117341312349152469759997869058851217919643931")
+        @test abs(I - IWolfram) < 1e-154
+    end
+end
+
 @testset "A value of agm." begin
   @test isapprox(
     agm(1, sqrt(2)),


### PR DESCRIPTION
Also added BigFloat unit test for ellipticF that exercises this change.  Fixes Issue #9.  As shown in the new unit test, comparison with a Wolfram Alpha result computed to 160 digits shows that with `setprecision(512)` the `ellipticF` result is accurate to within `1.e-154` absolute error.
```