### PR TITLE
Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.cov
 *.jl.mem
 /Manifest.toml
+/docs/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,9 @@ authors = ["Stéphane Laurent <laurent_step@outlook.fr>", "Peter Simon <peter_si
 version = "2.0.1"
 
 [deps]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-Documenter = "1.1"
 SpecialFunctions = "2"
 julia = "1.6"
 


### PR DESCRIPTION
Removed Documenter from the package-level Project.toml file.  So people who are simply `using EllipticFunctions` don't need to install Documenter.  This change doesn't interfere with building the documentation as long as the `docs` directory is first activated as the current Julia environment.